### PR TITLE
fix(openapi): Make ChatCompletionChoice.logprobs optional

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1072,11 +1072,28 @@ components:
           description: The index of the choice in the list of choices.
         message:
           $ref: '#/components/schemas/Message'
+        logprobs:
+          description: Log probability information for the choice.
+          type: object
+          nullable: true
+          properties:
+            content:
+              description: A list of message content tokens with log probability information.
+              type: array
+              items:
+                $ref: '#/components/schemas/ChatCompletionTokenLogprob'
+            refusal:
+              description: A list of message refusal tokens with log probability information.
+              type: array
+              items:
+                $ref: '#/components/schemas/ChatCompletionTokenLogprob'
+          required:
+            - content
+            - refusal
       required:
         - finish_reason
         - index
         - message
-        - logprobs
     ChatCompletionStreamChoice:
       type: object
       required:


### PR DESCRIPTION
## Summary

- Declare `logprobs` under `properties` of `ChatCompletionChoice` (mirroring `ChatCompletionStreamChoice`)
- Drop `logprobs` from `required` so generated SDK types emit it as an optional field

## Why

Previously the schema listed `logprobs` in `required` for `ChatCompletionChoice` but never declared the field under `properties`. The OpenAI spec keeps it `required` + `nullable: true` (i.e. must be present, value may be `null`), but in practice some providers proxied through the Inference Gateway (e.g. DeepSeek) omit the field entirely rather than sending `null`. Strict generated clients then fail to deserialize a successful chat completion.

This was observed downstream in the Rust SDK's `chat-example` against DeepSeek, where `serde_json::from_str` rejected a missing `logprobs` field on `ChatCompletionChoice`.

Making the field optional in the spec (rather than only patching it in each SDK's codegen) keeps generated types tolerant of both `null` and missing values across the provider matrix.
