### PR TITLE
ci: fix Node 20 deprecation and Go cache warnings in schema-sync workflows

### DIFF
--- a/.github/workflows/a2a-schema-sync.yml
+++ b/.github/workflows/a2a-schema-sync.yml
@@ -26,13 +26,10 @@ jobs:
         uses: actions/setup-go@v6.4.0
         with:
           go-version: "1.26.2"
-          cache: true
+          cache: false
 
-      - name: Install task
-        uses: arduino/setup-task@v2.0.0
-        with:
-          version: 3.48.0
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install Task
+        run: sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin v3.48.0
 
       - name: Install buf
         run: |

--- a/.github/workflows/mcp-schema-sync.yml
+++ b/.github/workflows/mcp-schema-sync.yml
@@ -22,11 +22,8 @@ jobs:
         with:
           node-version: "24.15.0"
 
-      - name: Install task
-        uses: arduino/setup-task@v2.0.0
-        with:
-          version: 3.48.0
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install Task
+        run: sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin v3.48.0
 
       - name: Download and convert MCP schema
         run: task mcp-schema-download


### PR DESCRIPTION
## Summary

The manually-dispatched schema-sync workflows succeed but emit **2 annotation warnings** on every run. This fixes both.

### 1. `Node.js 20 actions are deprecated` — `arduino/setup-task@v2.0.0`

The action runs on the deprecated Node 20 runtime. Its latest **release** is still `v2.0.0` (Feb 2024) and even its default branch is `using: node20` (the Node 24 upgrade PR is still open upstream), so there is **no released version to bump to**. Every other action in these workflows is already on Node 24.

Replaced it with Task's official install script, pinned to `v3.48.0` (the same version the action installed). No Node runtime, no GitHub token needed, and it matches the existing `buf` install pattern that already writes to `/usr/local/bin`. Applied to both `a2a-schema-sync.yml` and `mcp-schema-sync.yml`.

### 2. `Restore cache failed: Dependencies file is not found … Supported file pattern: go.mod`

`actions/setup-go` in `a2a-schema-sync.yml` had `cache: true`, but this repo has **no `go.mod`** (the A2A task installs its plugin via `go install …@latest`). With no dependency file, setup-go can't compute a cache key and warns every run, with no caching benefit. Set `cache: false`.

## Verification

These are `workflow_dispatch`-only workflows, so confirmation is a manual re-run after merge — **Actions → Sync A2A Schema and Create PR / Sync MCP Schema and Create PR → Run workflow** — then check the run summary shows **0 annotations**. Locally confirmed the install one-liner resolves and installs `task` `3.48.0`.