### PR TITLE
feat: declare the anthropic-version header via extra_headers

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -647,6 +647,8 @@ components:
           url: 'https://api.anthropic.com/v1'
           auth_type: 'xheader'
           supports_vision: true
+          extra_headers:
+            anthropic-version: '2023-06-01'
           endpoints:
             models:
               name: 'list_models'


### PR DESCRIPTION
Companion to inference-gateway/inference-gateway#428, which removes the generator's hardcoded `{{if eq $name "anthropic"}}` block and emits `ExtraHeaders` generically from `x-provider-configs`. This adds the `anthropic-version` header as data so the gateway's vendored copy and this origin stay in sync — without it, the gateway's next `task openapi:download` would revert the vendored edit.

Affected repos: inference-gateway (vendored copy already updated in #428). SDKs/docs unaffected — `extra_headers` was already part of the x-provider-configs shape parsed by the gateway's generator.