### PR TITLE
fix(openapi): Correct Z.AI base URL to https://api.z.ai/api/paas/v4

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -828,7 +828,7 @@ components:
               endpoint: '/chat/completions'
         zai:
           id: 'zai'
-          url: 'https://api.z.ai/v1'
+          url: 'https://api.z.ai/api/paas/v4'
           auth_type: 'bearer'
           supports_vision: true
           endpoints:
@@ -2872,7 +2872,7 @@ components:
                 - name: zai_api_url
                   env: 'ZAI_API_URL'
                   type: string
-                  default: 'https://api.z.ai/v1'
+                  default: 'https://api.z.ai/api/paas/v4'
                   description: 'ZAI API URL'
                 - name: zai_api_key
                   env: 'ZAI_API_KEY'


### PR DESCRIPTION
## Problem

The Z.AI provider URL `https://api.z.ai/v1` returns an nginx 404 — that path has never existed on Z.AI's API. Their OpenAI-compatible base is `https://api.z.ai/api/paas/v4` (verified: `/v1/models` → 404, `/api/paas/v4/models` → 401 auth required), consistent with [Z.AI's docs](https://docs.z.ai/api-reference/introduction).

The wrong URL was introduced with the provider in #107 but was harmless until inference-gateway#437 started generating provider constants from this spec, replacing the gateway's working hand-written default (`https://open.bigmodel.cn/api/paas/v4`). Since then `/proxy/zai/models` fails with 404.

## Changes

- Provider registry `zai.url`: `https://api.z.ai/v1` → `https://api.z.ai/api/paas/v4`
- `ZAI_API_URL` config default: same change

## Downstream

After release, `inference-gateway/inference-gateway` needs to re-vendor `openapi.yaml` and regenerate provider constants (`ZaiDefaultBaseURL`). May also ripple to `sdks` and `docs` config pages.