### PR TITLE
ci: forward dry_run to downstream schemas-sync dispatches

### DIFF
--- a/.github/workflows/sync-downstream.yml
+++ b/.github/workflows/sync-downstream.yml
@@ -1,0 +1,63 @@
+---
+name: Sync Downstream
+
+# Fans out the deterministic schemas->types sync to every OpenAPI consumer.
+# Each downstream repo hosts a thin `schemas-sync.yml` caller of the org
+# reusable workflow (inference-gateway/.github/.github/workflows/schemas-sync.yml),
+# which runs that repo's `task oas-sync SCHEMAS_REF=<ref>` and opens/updates an
+# idempotent PR on the fixed `schemas-sync` branch. This dispatcher is
+# fire-and-forget and safe to re-run: downstream re-runs update the existing
+# PR in place (or close it when the repo is back in sync).
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'schemas ref to sync (refs/tags/vX.Y.Z, refs/heads/main, or a SHA). Empty = each repo resolves the latest schemas release.'
+        required: false
+        type: string
+        default: ''
+      repository:
+        description: 'Single downstream repo to dispatch (omit = all of: sdk, python-sdk, rust-sdk, typescript-sdk, inference-gateway)'
+        required: false
+        type: string
+        default: ''
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/create-github-app-token@v3.2.0
+        id: app-token
+        with:
+          client-id: ${{ secrets.INFERENCE_GATEWAY_MAINTAINER_APP_ID }}
+          private-key: ${{ secrets.INFERENCE_GATEWAY_MAINTAINER_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            sdk
+            python-sdk
+            rust-sdk
+            typescript-sdk
+            inference-gateway
+
+      - name: Dispatch schemas-sync to downstream repos
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REF: ${{ inputs.ref }}
+          ONLY: ${{ inputs.repository }}
+        run: |
+          set -euo pipefail
+          repos="sdk python-sdk rust-sdk typescript-sdk inference-gateway"
+          if [ -n "$ONLY" ]; then
+            case " $repos " in
+              *" $ONLY "*) repos="$ONLY" ;;
+              *) echo "::error::unknown downstream repo '$ONLY' (expected one of: $repos)"; exit 1 ;;
+            esac
+          fi
+          for repo in $repos; do
+            echo "dispatching schemas-sync.yml on inference-gateway/$repo (ref='${REF:-latest release}')"
+            gh workflow run schemas-sync.yml --repo "inference-gateway/$repo" -f ref="$REF"
+          done

--- a/.github/workflows/sync-downstream.yml
+++ b/.github/workflows/sync-downstream.yml
@@ -63,7 +63,12 @@ jobs:
               *) echo "::error::unknown downstream repo '$ONLY' (expected one of: $repos)"; exit 1 ;;
             esac
           fi
+          failed=0
           for repo in $repos; do
             echo "dispatching schemas-sync.yml on inference-gateway/$repo (ref='${REF:-latest release}' dry_run=$DRY_RUN)"
-            gh workflow run schemas-sync.yml --repo "inference-gateway/$repo" -f ref="$REF" -f dry_run="$DRY_RUN"
+            if ! gh workflow run schemas-sync.yml --repo "inference-gateway/$repo" -f ref="$REF" -f dry_run="$DRY_RUN"; then
+              echo "::error::failed to dispatch inference-gateway/$repo (is its schemas-sync.yml caller merged to the default branch?)"
+              failed=1
+            fi
           done
+          exit "$failed"

--- a/.github/workflows/sync-downstream.yml
+++ b/.github/workflows/sync-downstream.yml
@@ -22,6 +22,11 @@ on:
         required: false
         type: string
         default: ''
+      dry_run:
+        description: 'Downstream runs preview the regeneration diff in their job summary without opening/updating PRs'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -48,6 +53,7 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           REF: ${{ inputs.ref }}
           ONLY: ${{ inputs.repository }}
+          DRY_RUN: ${{ inputs.dry_run }}
         run: |
           set -euo pipefail
           repos="sdk python-sdk rust-sdk typescript-sdk inference-gateway"
@@ -58,6 +64,6 @@ jobs:
             esac
           fi
           for repo in $repos; do
-            echo "dispatching schemas-sync.yml on inference-gateway/$repo (ref='${REF:-latest release}')"
-            gh workflow run schemas-sync.yml --repo "inference-gateway/$repo" -f ref="$REF"
+            echo "dispatching schemas-sync.yml on inference-gateway/$repo (ref='${REF:-latest release}' dry_run=$DRY_RUN)"
+            gh workflow run schemas-sync.yml --repo "inference-gateway/$repo" -f ref="$REF" -f dry_run="$DRY_RUN"
           done


### PR DESCRIPTION
Follow-up to #141 (merged before this commit landed on the branch): adds the `dry_run` input and forwards it to each downstream dispatch (`-f dry_run=...`). With it, downstream runs preview the regeneration diff in their job summary without opening/updating PRs.

Note: the checkbox only appears in the Actions UI once this is on `main`, and dispatching only succeeds once the downstream caller PRs are merged (inference-gateway/.github#116 first, then sdk#136, python-sdk#84, rust-sdk#100, typescript-sdk#166, inference-gateway#479).