### PR TITLE
fix(openapi): add x-enum-varnames to Messages API inline enums

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3019,6 +3019,9 @@ components:
           enum:
             - user
             - assistant
+          x-enum-varnames:
+            - MessagesMessageRoleUser
+            - MessagesMessageRoleAssistant
           description: The role of the message sender.
         content:
           description: |
@@ -3071,6 +3074,8 @@ components:
               type: string
               enum:
                 - tool
+              x-enum-varnames:
+                - MessagesToolChoiceTypeTool
               description: Always `tool`.
             name:
               type: string
@@ -3233,6 +3238,8 @@ components:
           type: string
           enum:
             - assistant
+          x-enum-varnames:
+            - MessagesResponseRoleAssistant
           description: Always `assistant`.
         content:
           type: array


### PR DESCRIPTION
## Problem

The v0.11.0 schemas-sync failed downstream in `inference-gateway/inference-gateway` ([run 29841950105](https://github.com/inference-gateway/inference-gateway/actions/runs/29841950105/job/88672798495)):

```text
providers/types/test_helpers.go:71:15: undefined: Tool
providers/types/test_helpers.go:85:14: undefined: Assistant
```

The Messages API schemas added in v0.11.0 include three inline enums without `x-enum-varnames`:

- `MessagesMessage.role` (`user`, `assistant`)
- `MessagesToolChoice` object variant `.type` (`tool`)
- `MessagesResponse.role` (`assistant`)

oapi-codegen derives constant names `User`/`Assistant`/`Tool` for them, which collide with `MessageRole`'s varnames. On collision oapi-codegen prefixes **both** enums, so the bare `Assistant`/`System`/`Tool`/`User` constants become `MessageRoleAssistant` etc. — breaking every hand-written reference in downstream Go consumers.

## Fix

Add `x-enum-varnames` with the repo's existing prefixed convention (`ResponseRoleAssistant`, `ResponseToolTypeFunction`, …): `MessagesMessageRoleUser`/`MessagesMessageRoleAssistant`, `MessagesToolChoiceTypeTool`, `MessagesResponseRoleAssistant`.

Verified locally: with these annotations, oapi-codegen v2.8.0 + the gateway's `.oapi-codegen.yaml` emits the bare `MessageRole` constants again and the generated types compile together with the gateway's hand-written helpers. Spectral lint, prettier, and `check-reachable` pass.

## Cross-repo impact

After merge (semantic-release cuts v0.11.1), re-dispatch `sync-downstream.yml` so all consumers re-sync: `inference-gateway`, `sdk` (Go, same collision), `python-sdk`, `rust-sdk`, `typescript-sdk`.

no docs ticket: internal-only schema annotation, no API surface change
