### PR TITLE
feat(openapi): add output_config effort to CreateMessagesRequest

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3178,10 +3178,35 @@ components:
           required:
             - type
             - budget_tokens
+        output_config:
+          $ref: '#/components/schemas/MessagesOutputConfig'
       required:
         - model
         - max_tokens
         - messages
+    MessagesOutputConfig:
+      type: object
+      description: |
+        Output configuration for a Messages API request.
+      properties:
+        effort:
+          type: string
+          enum:
+            - low
+            - medium
+            - high
+            - xhigh
+            - max
+          x-enum-varnames:
+            - MessagesOutputConfigEffortLow
+            - MessagesOutputConfigEffortMedium
+            - MessagesOutputConfigEffortHigh
+            - MessagesOutputConfigEffortXhigh
+            - MessagesOutputConfigEffortMax
+          description: |
+            Constrains how much effort the model spends on reasoning.
+            Lower effort yields faster responses and fewer reasoning
+            tokens.
     MessagesResponseContentBlock:
       type: object
       description: A content block within a Messages API response.


### PR DESCRIPTION
## What

Adds `output_config` to `CreateMessagesRequest` with a single `effort` property (`low | medium | high | xhigh | max`), mirroring Anthropic's GA `output_config.effort` field on `POST /v1/messages`. Modeled as a named component (`MessagesOutputConfig`) so oapi-codegen emits a named Go type with a `Valid()` enum instead of an anonymous struct.

## Why

The CLI is growing a `/effort` chat command to control reasoning effort at runtime. The OpenAI-compatible path already carries `reasoning_effort`, but the native Anthropic Messages path has no field for it - `thinking.budget_tokens` is rejected with a 400 on all current Anthropic models, so `output_config.effort` is the only wire format that works. The gateway forwards `/v1/messages` bodies verbatim, so no gateway change is needed - only the SDK types must carry the field.

## Verification

- `task openapi:lint` clean, `task openapi:format` unchanged, `bun scripts/check-reachable.js` OK (component reachable via `CreateMessagesRequest`).
- Dry-run of the Go SDK codegen (oapi-codegen v2.8.0 with the sdk repo's config) emits `CreateMessagesRequest.OutputConfig *MessagesOutputConfig` and the `MessagesOutputConfigEffort` enum as expected.

## Cross-repo impact

- `sdk` (Go): needs a `schemas-sync` run after release; the CLI consumes the new types from the next SDK version.
- `python-sdk` / `rust-sdk` / `typescript-sdk` / `inference-gateway`: routine sync, additive field only.
