### PR TITLE
feat(openapi): restructure Model modalities into nested input/output object

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -256,16 +256,22 @@ paths:
                         owned_by: 'openai'
                         served_by: 'openai'
                         modalities:
-                          - text
-                          - image
-                      - id: 'openai/gpt-4-turbo'
+                          input:
+                            - text
+                            - image
+                          output:
+                            - text
+                      - id: 'openai/gpt-image-2'
                         object: 'model'
                         created: 1687882410
                         owned_by: 'openai'
                         served_by: 'openai'
                         modalities:
-                          - text
-                          - image
+                          input:
+                            - text
+                            - image
+                          output:
+                            - image
         '400':
           description: Bad request - unsupported include value
           content:
@@ -1630,16 +1636,9 @@ components:
           $ref: '#/components/schemas/Provider'
         modalities:
           oneOf:
-            - type: array
-              items:
-                type: string
-                enum:
-                  - text
-                  - image
-                  - audio
-                  - video
+            - $ref: '#/components/schemas/ModelModalities'
             - type: 'null'
-          description: The modalities the model supports natively (included when `include=modalities`)
+          description: The input and output modalities of the model (included when `include=modalities`)
         context_window:
           oneOf:
             - $ref: '#/components/schemas/ContextWindow'
@@ -1656,6 +1655,33 @@ components:
         - created
         - owned_by
         - served_by
+    Modality:
+      type: string
+      description: A single input or output modality
+      enum:
+        - text
+        - image
+        - audio
+        - video
+    ModelModalities:
+      type: object
+      description: >-
+        The input and output modalities of a model, mirroring the models.dev dataset shape.
+        Vision models accept `image` in `input`; image-generation models list `image` in
+        `output` — when `output` carries `image` but not `text`, the model only generates
+        images and cannot chat.
+      properties:
+        input:
+          type: array
+          items:
+            $ref: '#/components/schemas/Modality'
+        output:
+          type: array
+          items:
+            $ref: '#/components/schemas/Modality'
+      required:
+        - input
+        - output
     ListModelsResponse:
       type: object
       description: Response structure for listing models


### PR DESCRIPTION
Restructures the `Model.modalities` field from a flat input-only array into a nested object mirroring the models.dev dataset shape:

```yaml
modalities:
  input: [text, image]
  output: [image]
```

New components: `Modality` (shared `text|image|audio|video` enum) and `ModelModalities` (`{input, output}`, both required).

**Why:** the flat array carried only *input* modalities, which makes image-generation detection impossible — real generators (e.g. `openai/gpt-image-2`) accept `[text, image]` input and are indistinguishable from vision chat models. Output modalities are the discriminator: `image` in `output` without `text` means the model only generates images and cannot chat. models.dev already publishes exactly this split, so the gateway's community sync maps 1:1.

**Breaking** (intentional, no back-compat shim): consumers of the v0.21 flat array must migrate.

Affected repos once released:
- `inference-gateway` — vendored `openapi.yaml`, generated types, `communitygen` modalities sync (should also emit the `output` field and re-sync from a fresh models.dev tarball), `/v1/models?include=modalities` response
- `sdk` (Go) + other SDKs — regenerate `Model` types
- `cli` — model picker labels, vision note suppression, image-gen filtering (PR inference-gateway/cli#1031)
- `docs` — models endpoint reference
